### PR TITLE
Fix task set creation and execution updates

### DIFF
--- a/app/controllers/executions_controller.rb
+++ b/app/controllers/executions_controller.rb
@@ -106,7 +106,7 @@ class ExecutionsController < ApplicationController
       return
     end
     @data['version'] = params['version'] # TODO: ???????
-    @data['updated_by'] = @current_user
+    @data['updated_by'] = @current_user.id
 
     cases = @data.delete('cases')
     tag_list = @data.delete('tag_list')

--- a/app/controllers/executions_controller.rb
+++ b/app/controllers/executions_controller.rb
@@ -106,7 +106,7 @@ class ExecutionsController < ApplicationController
       return
     end
     @data['version'] = params['version'] # TODO: ???????
-    @data['updated_by'] = @current_user.id
+    @data['updated_by'] = @current_user
 
     cases = @data.delete('cases')
     tag_list = @data.delete('tag_list')

--- a/app/controllers/test_sets_controller.rb
+++ b/app/controllers/test_sets_controller.rb
@@ -32,7 +32,7 @@ class TestSetsController < ApplicationController
     tag_list = @data.delete(:tag_list)
     case_data = @data.delete(:cases)
     @data[:project_id] = @project.id
-    @data[:created_by] = @data[:updated_by] = @current_user
+    @data[:created_by] = @data[:updated_by] = @current_user.id
     
     @set = TestSet.create_with_cases!(@data, case_data, tag_list)
     
@@ -50,7 +50,7 @@ class TestSetsController < ApplicationController
     tag_list = @data.delete(:tag_list)
     case_data = @data.delete(:cases)
     @data[:project_id] = @project.id if @data[:project_id].nil?
-    @data[:updated_by] = @current_user
+    @data[:updated_by] = @current_user.id
     
     @test_set.update_with_cases!(@data, case_data, tag_list)
     

--- a/app/controllers/test_sets_controller.rb
+++ b/app/controllers/test_sets_controller.rb
@@ -32,7 +32,7 @@ class TestSetsController < ApplicationController
     tag_list = @data.delete(:tag_list)
     case_data = @data.delete(:cases)
     @data[:project_id] = @project.id
-    @data[:created_by] = @data[:updated_by] = @current_user.id
+    @data[:created_by] = @data[:updated_by] = @current_user
     
     @set = TestSet.create_with_cases!(@data, case_data, tag_list)
     
@@ -50,7 +50,7 @@ class TestSetsController < ApplicationController
     tag_list = @data.delete(:tag_list)
     case_data = @data.delete(:cases)
     @data[:project_id] = @project.id if @data[:project_id].nil?
-    @data[:updated_by] = @current_user.id
+    @data[:updated_by] = @current_user
     
     @test_set.update_with_cases!(@data, case_data, tag_list)
     


### PR DESCRIPTION
Since the move to Rails 3.2.11, it hasn't been possible to create Task Sets or save changes to executions.  The culprit was passing the user object on to ActiveRecord rather than the user ID.  Old Rails versions used to convert that to 1, but new versions throw an error.  This discussion touches on the problem: http://stackoverflow.com/questions/13348980/activerecord-to-i-method-removed-in-rails-3-2-9
