### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ otherwise skip to [Install Tarantula](#install-tarantula)
 Install RVM dependencies:
 
 ```
-yum install make gcc readline-devel zlib-devel openssl-devel libyaml
+yum install make gcc readline-devel zlib-devel openssl-devel libyaml redhat-lsb
 ```
 
 Install RVM system wide:


### PR DESCRIPTION
redhat-lsb is needed by install.sh.  This is not present on a CentOS 6.3 minimal install.
